### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/exc/block.go
+++ b/exc/block.go
@@ -25,14 +25,14 @@ type Block struct {
 	finallies []func()
 }
 
-// Start a Try/Catch/Finally block. Any exception thrown in the Try block can
+// Try starts a Try/Catch/Finally block. Any exception thrown in the Try block can
 // be caught by a Catch block (if registered for the Exception type or a parent
 // exception type).
 func Try(try func()) *Block {
 	return &Block{try: try}
 }
 
-// Start a Try/Catch/Finally block. You supply to functions, the first one
+// Close starts a Try/Catch/Finally block. You supply to functions, the first one
 // creates a closable resource and returns it. This resources is supplied to the
 // the second function which acts as a normal try. Whether the try fails or
 // succeeds the Close() function is always called on the resource that was
@@ -59,7 +59,7 @@ func Close(makeCloser func() io.Closer, try func(io.Closer)) *Block {
 	})
 }
 
-// Add a catch function for a specific Throwable. If your Throwable struct
+// Catch adds a catch function for a specific Throwable. If your Throwable struct
 // "inherits" from another struct like so:
 //
 //     type MyException struct {
@@ -82,7 +82,7 @@ func (b *Block) Catch(exc Throwable, do func(Throwable)) *Block {
 	return b
 }
 
-// Add a finally block. These will be run whether or not an exception was
+// Finally adds a finally block. These will be run whether or not an exception was
 // thrown. However, if a regular panic occurs this function will not be run and
 // the panic will behave as normal.
 func (b *Block) Finally(finally func()) *Block {

--- a/exc/exception.go
+++ b/exc/exception.go
@@ -85,7 +85,7 @@ type Exception struct {
 	Errors []*Error
 }
 
-// Return itself.
+// Exc returns itself.
 func (e *Exception) Exc() *Exception {
 	return e
 }
@@ -104,7 +104,7 @@ func (e *Exception) String() string {
 	return e.Error()
 }
 
-// Add another *Error to the list of *Error
+// Chain adds another *Error to the list of *Error
 func (e *Exception) Chain(err *Error) Throwable {
 	e.Errors = append(e.Errors, err)
 	return e

--- a/heap/pq.go
+++ b/heap/pq.go
@@ -60,12 +60,12 @@ func (h *Heap) Size() int {
 	return len(h.list)
 }
 
-// Is this a min heap?
+// MinHeap Is this a min heap?
 func (h *Heap) MinHeap() bool {
 	return h.min
 }
 
-// Is this a max heap?
+// MaxHeap Is this a max heap?
 func (h *Heap) MaxHeap() bool {
 	return !h.min
 }

--- a/heap/unique.go
+++ b/heap/unique.go
@@ -41,12 +41,12 @@ func (u *UniquePQ) Push(priority int, item interface{}) {
 	u.Add(priority, item.(types.Hashable))
 }
 
-// Get the top element
+// Peek gets the top element
 func (u *UniquePQ) Peek() interface{} {
 	return u.pq.Peek()
 }
 
-// Get and remove the top element
+// Pop gets and remove the top element
 func (u *UniquePQ) Pop() interface{} {
 	item := u.pq.Pop().(types.Hashable)
 	u.set.Delete(item)

--- a/linked/linked.go
+++ b/linked/linked.go
@@ -17,7 +17,7 @@ type Node struct {
 	Next, Prev *Node
 }
 
-// Compares the Data of the node to the passed element.
+// Equals compares the Data of the node to the passed element.
 func (n *Node) Equals(b types.Equatable) bool {
 	switch x := b.(type) {
 	case *Node:
@@ -27,7 +27,7 @@ func (n *Node) Equals(b types.Equatable) bool {
 	}
 }
 
-// Compares the Data of the node to the passed element.
+// Less compares the Data of the node to the passed element.
 func (n *Node) Less(b types.Sortable) bool {
 	switch x := b.(type) {
 	case *Node:

--- a/set/setmap.go
+++ b/set/setmap.go
@@ -75,22 +75,22 @@ func (s *SetMap) Subtract(other types.Set) (types.Set, error) {
 	return Subtract(s, other)
 }
 
-// Is s a subset of o?
+// Subset Is s a subset of o?
 func (s *SetMap) Subset(o types.Set) bool {
 	return Subset(s, o)
 }
 
-// Is s a proper subset of o?
+// ProperSubset Is s a proper subset of o?
 func (s *SetMap) ProperSubset(o types.Set) bool {
 	return ProperSubset(s, o)
 }
 
-// Is s a superset of o?
+// Superset Is s a superset of o?
 func (s *SetMap) Superset(o types.Set) bool {
 	return Superset(s, o)
 }
 
-// Is s a proper superset of o?
+// ProperSuperset Is s a proper superset of o?
 func (s *SetMap) ProperSuperset(o types.Set) bool {
 	return ProperSuperset(s, o)
 }

--- a/set/sortedset.go
+++ b/set/sortedset.go
@@ -156,22 +156,22 @@ func (s *SortedSet) Overlap(o *SortedSet) bool {
 	return false
 }
 
-// Is s a subset of o?
+// Subset Is s a subset of o?
 func (s *SortedSet) Subset(o types.Set) bool {
 	return Subset(s, o)
 }
 
-// Is s a proper subset of o?
+// ProperSubset Is s a proper subset of o?
 func (s *SortedSet) ProperSubset(o types.Set) bool {
 	return ProperSubset(s, o)
 }
 
-// Is s a superset of o?
+// Superset Is s a superset of o?
 func (s *SortedSet) Superset(o types.Set) bool {
 	return Superset(s, o)
 }
 
-// Is s a proper superset of o?
+// ProperSuperset Is s a proper superset of o?
 func (s *SortedSet) ProperSuperset(o types.Set) bool {
 	return ProperSuperset(s, o)
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?