### PR TITLE
Fix argument forwarding syntax when printing error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -35,7 +35,7 @@ func Logf(level, format string, args ...interface{}) {
 	}
 	pc, _, line, ok := runtime.Caller(1)
 	if !ok {
-		log.Printf(format, args)
+		log.Printf(format, args...)
 		return
 	}
 	fn := runtime.FuncForPC(pc)


### PR DESCRIPTION
Compilation of `timtadh/data-structures/errors` fails with Go 1.18:
```
# github.com/timtadh/data-structures/errors
./errors.go:38:3: missing ... in args forwarded to printf-like function
```

This PR just adds the missing `...` characters.